### PR TITLE
docs: add link to fetchkit.org ecosystem site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 # Chaos Proxy
 
+
+> Part of the **[fetch-kit ecosystem](https://fetchkit.org)** - production-ready fetch utilities and chaos-testing tools.
+
 Chaos Proxy is a proxy server for injecting configurable network chaos (latency, failures, connection drops, rate-limiting, and transforms) into HTTP traffic.
 
 Use it via CLI or programmatically with ordered middleware chains (global and per-route).


### PR DESCRIPTION
Adds a brief ecosystem callout under the h1 in the README, linking to https://fetchkit.org.