### PR TITLE
ci: use GitHub App token for changesets version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -42,4 +50,4 @@ jobs:
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage/
 *.log
 *.tmp
 
+# GitHub App private key (never commit)
+*.private-key.pem
+
 # Examples output
 examples/**/*.log
 examples/**/*.tmp


### PR DESCRIPTION
Replaces the expired CHANGESETS_TOKEN PAT with a short-lived token minted from the fetch-kit-automation GitHub App. Fixes the 'bad credentials' failure in the Version Packages workflow.